### PR TITLE
Pass codec as reference instead of in the template parameter

### DIFF
--- a/src/coproc_link_parser.h
+++ b/src/coproc_link_parser.h
@@ -8,11 +8,12 @@
 
 namespace rb {
 
-template <typename MessageType, const pb_msgdesc_t* FieldDesc, rb::CoprocCodec* Codec>
+template <typename MessageType, const pb_msgdesc_t* FieldDesc>
 class CoprocLinkParser {
 public:
-    CoprocLinkParser()
-        : m_buf_index(0)
+    CoprocLinkParser(rb::CoprocCodec& codec)
+        : m_codec(codec)
+        , m_buf_index(0)
         , m_frame_len(0)
         , m_state(AwaitingStart) {
         memset(&m_last_msg, 0, sizeof(MessageType));
@@ -32,7 +33,7 @@ public:
             m_buf[m_buf_index++] = byte;
             if (m_buf_index == m_frame_len) {
                 m_state = AwaitingStart;
-                return Codec->decode(m_buf.data(), m_buf_index, FieldDesc, &m_last_msg);
+                return m_codec.decode(m_buf.data(), m_buf_index, FieldDesc, &m_last_msg);
             }
         }
         return false;
@@ -49,6 +50,7 @@ private:
 
     std::array<uint8_t, 255> m_buf;
     MessageType m_last_msg;
+    CoprocCodec& m_codec;
     size_t m_buf_index;
     size_t m_frame_len;
     State m_state;


### PR DESCRIPTION
S tou template to nejde použít ve fci takhle:

```cpp
void Manager::consumerRoutine() {

    rb::CoprocCodec codec;
    rb::CoprocLinkParser<CoprocStat, &CoprocStat_msg> parser(codec);

}
```